### PR TITLE
Debugging

### DIFF
--- a/R/cmrbdt.finder.numeric.ahrq.R
+++ b/R/cmrbdt.finder.numeric.ahrq.R
@@ -42,7 +42,7 @@
 cmrbdt.finder.numeric.ahrq <-
   function(icd_codes,
            out,
-           country_code,
+           country_code = 'US',
            include_acute = rep(TRUE, length(icd_codes)),
            icd_ver = 9,
            ver = "3.7"){

--- a/R/cmrbdt.finder.numeric.charlson.R
+++ b/R/cmrbdt.finder.numeric.charlson.R
@@ -9,7 +9,7 @@
 cmrbdt.finder.numeric.charlson_Deyo1992 <- 
   function(icd_codes, 
            out,
-           country_code,
+           country_code = 'US',
            include_acute = rep(TRUE, length(icd_codes)),
            icd_ver = 9){
   if (any(icd_ver != 9)) { stop("Only ICD-9 version is supported for the Deyo 1992")}

--- a/R/cmrbdt.finder.numeric.elixhauser.R
+++ b/R/cmrbdt.finder.numeric.elixhauser.R
@@ -7,7 +7,7 @@
 cmrbdt.finder.numeric.elixhauser_Elixhauser1998 <- 
   function(icd_codes, 
            out,
-           country_code,
+           country_code = 'US',
            include_acute = rep(TRUE, length(icd_codes)),
            icd_ver = 9){
   if (any(icd_ver != 9)) { stop("Only ICD-9 version is supported for the Deyo 1992")}

--- a/R/cmrbdt.finder.regex.RCS_charlson.R
+++ b/R/cmrbdt.finder.regex.RCS_charlson.R
@@ -120,7 +120,7 @@ cmrbdt.finder.regex.charlson_Armitage2010 <-
 
     function(icd_codes,
              out,
-             country_code,
+             country_code = 'US',
              include_acute = rep(TRUE, times=length(icd_codes)),
              icd_ver = rep(FALSE, times=length(icd_codes))){
 

--- a/R/cmrbdt.finder.regex.charlson.R
+++ b/R/cmrbdt.finder.regex.charlson.R
@@ -140,7 +140,7 @@ cmrbdt.finder.regex.charlson_Quan2005 <-
 
     function(icd_codes,
              out,
-             country_code,
+             country_code = 'US',
              include_acute = rep(TRUE, times=length(icd_codes)),
              icd_ver = rep(FALSE, times=length(icd_codes))){
 
@@ -299,7 +299,7 @@ cmrbdt.finder.regex.charlson_Sundarajan2004 <-
 
     function(icd_codes,
              out,
-             country_code,
+             country_code = 'US',
              include_acute = rep(TRUE, times=length(icd_codes)),
              icd_ver = rep(FALSE, times=length(icd_codes))){
 

--- a/R/cmrbdt.finder.regex.elixhauser.R
+++ b/R/cmrbdt.finder.regex.elixhauser.R
@@ -349,7 +349,7 @@ cmrbdt.finder.regex.elixhauser_Quan2005 <-
 
     function(icd_codes,
              out,
-             country_code,
+             country_code = 'US',
              include_acute = rep(TRUE, times=length(icd_codes)),
              icd_ver = rep(FALSE, times=length(icd_codes))){
 

--- a/R/peprocessors.R
+++ b/R/peprocessors.R
@@ -148,11 +148,11 @@ preproc.code.splitter <- function(icd, icd_ver,
                                   trim = TRUE){
   if (trim){ icd <- str_trim(icd) }
   # Remove empty icd-codes
-  empty <- which(icd != "")
+  empty <- which(icd == "")
   if (length(empty) > 0)
     icd <- icd[-empty]
 
-  code_list <- strsplit(icd, " ")
+  code_list <- strsplit(icd, split_str)
   icd <- unlist(code_list, use.names = FALSE)
   if (!missing(icd_ver)) {
     if (length(empty) > 0)


### PR DESCRIPTION
fixed errors in R cmd check:
- country_code is always set to the default 'US' the finder functions
- preproc.code.splitter() now actually uses the split_str argument
- preproc.code.splitter() checks for empty elements as intended
